### PR TITLE
NP-2508 list log responses

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -111,12 +111,12 @@
   version = "v0.0.39"
 
 [[projects]]
-  digest = "1:5aa788d8961cf7d63d9a3f7bda416aa374f06c2a46fad2a0a7d5c530cbcc0065"
+  digest = "1:6d73d2765df384574a8b2533ecc87716abd7bad857cf171c2ae6ec6f4fc0b984"
   name = "github.com/nalej/grpc-log-download-manager-go"
   packages = ["."]
   pruneopts = ""
-  revision = "2b1e9843b549229e7184223a7a7b080d751cfde3"
-  version = "v0.0.1"
+  revision = "309d10e59a5d5746a6626f0d6614d73233cc33f8"
+  version = "v0.0.2"
 
 [[projects]]
   digest = "1:ba1b6bc93bc388dddeb0db8975ca32312921508dfff13803fb58c623c2350908"
@@ -369,6 +369,7 @@
     "github.com/nalej/grpc-application-manager-go",
     "github.com/nalej/grpc-common-go",
     "github.com/nalej/grpc-log-download-manager-go",
+    "github.com/nalej/grpc-organization-go",
     "github.com/nalej/grpc-utils/pkg/conversions",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[constraint]]
   name = "github.com/nalej/grpc-log-download-manager-go"
-  version = "=v0.0.1"
+  version = "=v0.0.2"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/internal/pkg/entities/entities.go
+++ b/internal/pkg/entities/entities.go
@@ -83,3 +83,4 @@ func Sort(elements []*grpc_application_manager_go.LogEntryResponse, order grpc_c
 	}
 	return elements
 }
+

--- a/internal/pkg/entities/validator.go
+++ b/internal/pkg/entities/validator.go
@@ -19,13 +19,32 @@ package entities
 import (
 	"github.com/nalej/derrors"
 	"github.com/nalej/grpc-log-download-manager-go"
+	"github.com/nalej/grpc-organization-go"
 )
 
 const emptyOrganizationId = "organization_id cannot be empty"
-
+const emptyRequestId = "request_id cannot be empty"
 
 func ValidDownloadLogRequest(request *grpc_log_download_manager_go.DownloadLogRequest) derrors.Error {
 	if request.OrganizationId == "" {
+		return derrors.NewInvalidArgumentError(emptyOrganizationId)
+	}
+	return nil
+}
+
+func ValidDownloadRequestId(request *grpc_log_download_manager_go.DownloadRequestId) derrors.Error {
+	if request.OrganizationId == "" {
+		return derrors.NewInvalidArgumentError(emptyOrganizationId)
+	}
+	if request.RequestId == "" {
+		return derrors.NewInvalidArgumentError(emptyRequestId)
+	}
+
+	return nil
+}
+
+func ValidOrganizationId (organizationID *grpc_organization_go.OrganizationId) derrors.Error{
+	if organizationID.OrganizationId == "" {
 		return derrors.NewInvalidArgumentError(emptyOrganizationId)
 	}
 	return nil

--- a/internal/pkg/server/interceptor/interceptor.go
+++ b/internal/pkg/server/interceptor/interceptor.go
@@ -19,7 +19,6 @@ package interceptor
 import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/nalej/derrors"
-	"github.com/rs/zerolog/log"
 	"net/http"
 )
 
@@ -86,8 +85,6 @@ func (i *Interceptor) checkJWT(r *http.Request) derrors.Error {
 
 	r.Header.Add(UserID, userAuth.UserID)
 	r.Header.Add(OrganizationID, userAuth.OrganizationID)
-	log.Debug().Interface("claim", userAuth).Msg("Claim")
-	log.Debug().Interface("Header", r.Header).Msg("Header!!")
 
 	// check the role permissions
 	found := false

--- a/internal/pkg/server/log-manager/handler.go
+++ b/internal/pkg/server/log-manager/handler.go
@@ -19,6 +19,7 @@ package log_manager
 import (
 	"context"
 	"github.com/nalej/grpc-log-download-manager-go"
+	"github.com/nalej/grpc-organization-go"
 	"github.com/nalej/grpc-utils/pkg/conversions"
 	"github.com/nalej/log-download-manager/internal/pkg/entities"
 )
@@ -50,7 +51,26 @@ func (h *Handler) DownloadLog(_ context.Context, request *grpc_log_download_mana
 
 // Check asks for a download operation state
 func (h *Handler) Check(_ context.Context, request *grpc_log_download_manager_go.DownloadRequestId) (*grpc_log_download_manager_go.DownloadLogResponse, error) {
+
+	vErr := entities.ValidDownloadRequestId(request)
+	if vErr != nil {
+		return nil, conversions.ToGRPCError(vErr)
+	}
 	response, err := h.Manager.Check(request)
+	if err != nil {
+		return nil, conversions.ToDerror(err)
+	}
+	return response, nil
+}
+
+
+func (h *Handler) List(_ context.Context, organizationID *grpc_organization_go.OrganizationId) (*grpc_log_download_manager_go.DownloadLogResponse, error) {
+
+	vErr := entities.ValidOrganizationId(organizationID)
+	if vErr != nil {
+		return nil, conversions.ToGRPCError(vErr)
+	}
+	response, err := h.Manager.List(organizationID)
 	if err != nil {
 		return nil, conversions.ToDerror(err)
 	}

--- a/internal/pkg/server/log-manager/handler.go
+++ b/internal/pkg/server/log-manager/handler.go
@@ -64,7 +64,7 @@ func (h *Handler) Check(_ context.Context, request *grpc_log_download_manager_go
 }
 
 
-func (h *Handler) List(_ context.Context, organizationID *grpc_organization_go.OrganizationId) (*grpc_log_download_manager_go.DownloadLogResponse, error) {
+func (h *Handler) List(_ context.Context, organizationID *grpc_organization_go.OrganizationId) (*grpc_log_download_manager_go.DownloadLogResponseList, error) {
 
 	vErr := entities.ValidOrganizationId(organizationID)
 	if vErr != nil {

--- a/internal/pkg/server/log-manager/manager.go
+++ b/internal/pkg/server/log-manager/manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nalej/grpc-application-manager-go"
 	"github.com/nalej/grpc-common-go"
 	"github.com/nalej/grpc-log-download-manager-go"
+	"github.com/nalej/grpc-organization-go"
 	"github.com/nalej/grpc-utils/pkg/conversions"
 	"github.com/nalej/log-download-manager/internal/pkg/entities"
 	"github.com/nalej/log-download-manager/internal/pkg/utils"
@@ -137,4 +138,8 @@ func (m *Manager) Check(request *grpc_log_download_manager_go.DownloadRequestId)
 	}
 
 	return entities.NewDownloadLogResponse(request, operation), nil
+}
+
+func (m *Manager) List(organizationID *grpc_organization_go.OrganizationId) (*grpc_log_download_manager_go.DownloadLogResponse, derrors.Error) {
+	return nil, nil
 }

--- a/internal/pkg/server/log-manager/manager.go
+++ b/internal/pkg/server/log-manager/manager.go
@@ -80,7 +80,7 @@ func (m *Manager) download(request *grpc_log_download_manager_go.DownloadLogRequ
 			log.Debug().Int("responses", len(response.Entries)).Msg("entries retrieved")
 			if len(response.Entries) > 0 {
 				// 4.- Copy the log entries in a file ordered
-				err = utils.AppendResponses(entities.Sort(response.Entries, request.Order.Order), utils.GetFilePath(m.DownloadDirectory, requestId))
+				err = utils.AppendResponses(entities.Sort(response.Entries, request.Order.Order), utils.GetFilePath(m.DownloadDirectory, requestId), request.IncludeMetadata)
 				if err != nil {
 					updateErr := m.opeCache.Update(requestId, utils.Error, err.Error())
 					if updateErr != nil {

--- a/internal/pkg/utils/download_cache.go
+++ b/internal/pkg/utils/download_cache.go
@@ -154,3 +154,23 @@ func (d *DownloadCache) Remove(requestId string) derrors.Error {
 
 	return nil
 }
+
+// TODO: añadir el organizationID
+func (d *DownloadCache) List () ([]*DownloadOperation, derrors.Error) {
+
+	d.Lock()
+	defer d.Unlock()
+
+	list := make ([]*DownloadOperation, 0)
+
+	for _, ope := range d.cache {
+		list = append(list, ope)
+	}
+
+	return list, nil
+
+}
+
+func (d *DownloadCache) Clean(){
+	d.cache = make(map[string]*DownloadOperation, 0)
+}

--- a/internal/pkg/utils/download_cache.go
+++ b/internal/pkg/utils/download_cache.go
@@ -29,6 +29,7 @@ type DownloadLogState int
 
 const (
 	ExpirationTime = 10 * time.Minute
+	ExpiredMsg = "Expired"
 )
 
 const (
@@ -152,6 +153,11 @@ func (d *DownloadCache) Get(requestId string) (*DownloadOperation, derrors.Error
 		return nil, derrors.NewNotFoundError("download operation").WithParams(requestId)
 	}
 
+	if operation.State == Ready && operation.Expiration < time.Now().UnixNano(){
+		operation.State = Error
+		operation.Info = ExpiredMsg
+	}
+
 	return operation, nil
 }
 
@@ -199,6 +205,10 @@ func (d *DownloadCache) List(organizationID string) ([]*DownloadOperation, derro
 
 	for _, ope := range d.cache {
 		if ope.OrganizationId == organizationID {
+			if ope.State == Ready && ope.Expiration < time.Now().UnixNano(){
+				ope.State = Error
+				ope.Info = ExpiredMsg
+			}
 			list = append(list, ope)
 		}
 	}

--- a/internal/pkg/utils/download_cache_test.go
+++ b/internal/pkg/utils/download_cache_test.go
@@ -25,8 +25,13 @@ import (
 var _ = ginkgo.Describe("Utils", func() {
 
 	var downloadCache  *DownloadCache
+
 	ginkgo.BeforeSuite(func() {
 		downloadCache = NewDownloadCache()
+	})
+
+	ginkgo.BeforeEach(func() {
+		downloadCache.Clean()
 	})
 
 	ginkgo.Context("Adding new operation", func() {
@@ -94,7 +99,19 @@ var _ = ginkgo.Describe("Utils", func() {
 			err := downloadCache.Update(requestID, Generating, "")
 			gomega.Expect(err).NotTo(gomega.Succeed())
 
+		})
+	})
+	ginkgo.Context("Listing operations", func() {
+		ginkgo.It("should be able to list operations", func() {
+			num := 5
+			for i:= 0; i < num; i++ {
+				_, err := downloadCache.Add(uuid.New().String(), 0, 0)
+				gomega.Expect(err).To(gomega.Succeed())
+			}
 
+			list, err := downloadCache.List()
+			gomega.Expect(err).To(gomega.Succeed())
+			gomega.Expect(len(list)).Should(gomega.Equal(num))
 
 		})
 	})

--- a/internal/pkg/utils/download_cache_test.go
+++ b/internal/pkg/utils/download_cache_test.go
@@ -25,6 +25,7 @@ import (
 var _ = ginkgo.Describe("Utils", func() {
 
 	var downloadCache  *DownloadCache
+	var organizationID string
 
 	ginkgo.BeforeSuite(func() {
 		downloadCache = NewDownloadCache("/test/", "nalej.tech")
@@ -32,12 +33,13 @@ var _ = ginkgo.Describe("Utils", func() {
 
 	ginkgo.BeforeEach(func() {
 		downloadCache.Clean()
+		organizationID = uuid.New().String()
 	})
 
 	ginkgo.Context("Adding new operation", func() {
 		ginkgo.It("should be able to add a new one", func() {
 			requestID := uuid.New().String()
-			_, err := downloadCache.Add(requestID, 0, 0)
+			_, err := downloadCache.Add(organizationID, requestID, 0, 0)
 			gomega.Expect(err).To(gomega.Succeed())
 
 			ope, err := downloadCache.Get(requestID)
@@ -48,10 +50,10 @@ var _ = ginkgo.Describe("Utils", func() {
 		})
 		ginkgo.It("should not be able to add one operation twice", func() {
 			requestID := uuid.New().String()
-			_, err := downloadCache.Add(requestID, 0, 0)
+			_, err := downloadCache.Add(organizationID, requestID, 0, 0)
 			gomega.Expect(err).To(gomega.Succeed())
 
-			_, err = downloadCache.Add(requestID, 0, 0)
+			_, err = downloadCache.Add(organizationID, requestID, 0, 0)
 			gomega.Expect(err).NotTo(gomega.Succeed())
 
 
@@ -61,7 +63,7 @@ var _ = ginkgo.Describe("Utils", func() {
 	ginkgo.Context("Removing an operation", func() {
 		ginkgo.It("should be able to remove an operation", func() {
 			requestID := uuid.New().String()
-			_, err := downloadCache.Add(requestID, 0, 0)
+			_, err := downloadCache.Add(organizationID, requestID, 0, 0)
 			gomega.Expect(err).To(gomega.Succeed())
 
 			err = downloadCache.Remove(requestID)
@@ -81,7 +83,7 @@ var _ = ginkgo.Describe("Utils", func() {
 	ginkgo.Context("Updating an operation", func() {
 		ginkgo.It("should be able to update an operation", func() {
 			requestID := uuid.New().String()
-			_, err := downloadCache.Add(requestID, 0, 0)
+			_, err := downloadCache.Add(organizationID, requestID, 0, 0)
 			gomega.Expect(err).To(gomega.Succeed())
 
 			err = downloadCache.Update(requestID, Generating, "")
@@ -105,13 +107,27 @@ var _ = ginkgo.Describe("Utils", func() {
 		ginkgo.It("should be able to list operations", func() {
 			num := 5
 			for i:= 0; i < num; i++ {
-				_, err := downloadCache.Add(uuid.New().String(), 0, 0)
+				_, err := downloadCache.Add(organizationID, uuid.New().String(), 0, 0)
 				gomega.Expect(err).To(gomega.Succeed())
 			}
 
-			list, err := downloadCache.List()
+			list, err := downloadCache.List(organizationID)
 			gomega.Expect(err).To(gomega.Succeed())
 			gomega.Expect(len(list)).Should(gomega.Equal(num))
+
+		})
+	})
+	ginkgo.Context("Listing operations", func() {
+		ginkgo.It("should be able to list an empty list of operations", func() {
+			num := 5
+			for i:= 0; i < num; i++ {
+				_, err := downloadCache.Add(organizationID, uuid.New().String(), 0, 0)
+				gomega.Expect(err).To(gomega.Succeed())
+			}
+
+			list, err := downloadCache.List(uuid.New().String())
+			gomega.Expect(err).To(gomega.Succeed())
+			gomega.Expect(len(list)).Should(gomega.Equal(0))
 
 		})
 	})

--- a/internal/pkg/utils/zip_files_test.go
+++ b/internal/pkg/utils/zip_files_test.go
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Zip Files", func() {
 				{Msg:"entry 3", Timestamp:time.Now().UnixNano()},
 			}
 			// source, target
-			AppendResponses(responses, path)
+			AppendResponses(responses, path, false)
 		})
 		ginkgo.It("should be create zip file", func() {
 
@@ -66,7 +66,7 @@ var _ = ginkgo.Describe("Zip Files", func() {
 				{Msg:"entry 3", Timestamp:time.Now().UnixNano()},
 			}
 			// source, target
-			err = AppendResponses(responses, path)
+			err = AppendResponses(responses, path, false)
 			gomega.Expect(err).To(gomega.Succeed())
 
 			err = ZipFiles(fmt.Sprintf("%stest.zip",testDir), []string{path})


### PR DESCRIPTION
#### What does this PR do?
- implements List to retrieve a list of status responses
- write the log file according to `include_metadata` field
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?
 1. executing
````
./bin/public-api-cli log download search --metadata=true
````
and checking the file generated
````
[2019-12-12 09:47:47.466 +0000 UTC][DESCRIPTOR-Pinger][INSTANCE-Ping01][SERVICE-GROUP-ping-group][SERVICE-ping]:PING ping-e44dbc6c-d-f9ed842e-1-OUT-out.service.nalej (172.18.0.1): 56 data bytes
[2019-12-12 09:48:26.324 +0000 UTC][DESCRIPTOR-Pinger][INSTANCE-Ping02][SERVICE-GROUP-ping-group][SERVICE-ping]:PING ping-e44dbc6c-d-a158d2d6-2-OUT-out.service.nalej (172.18.0.1): 56 data bytes
[2019-12-12 09:49:04.768 +0000 UTC][DESCRIPTOR-Pinger][INSTANCE-Ping03][SERVICE-GROUP-ping-group][SERVICE-ping]:PING ping-e44dbc6c-d-d4b3836c-5-OUT-out.service.nalej (172.18.0.1): 56 data bytes
[2019-12-12 10:18:20.211 +0000 UTC][DESCRIPTOR-Pinger][INSTANCE-otro][SERVICE-GROUP-ping-group][SERVICE-ping]:PING ping-e44dbc6c-d-a78806a4-8-OUT-out.service.nalej (172.18.0.1): 56 data bytes
````

2. executing
````
./bin/public-api-cli log download search 
````
and checking the file generated
````
PING ping-e44dbc6c-d-f9ed842e-1-OUT-out.service.nalej (172.18.0.1): 56 data bytes
PING ping-e44dbc6c-d-a158d2d6-2-OUT-out.service.nalej (172.18.0.1): 56 data bytes
PING ping-e44dbc6c-d-d4b3836c-5-OUT-out.service.nalej (172.18.0.1): 56 data bytes
PING ping-e44dbc6c-d-a78806a4-8-OUT-out.service.nalej (172.18.0.1): 56 data bytes
PING ping-e44dbc6c-d-e9229600-e-OUT-out.service.nalej (172.18.0.1): 56 data bytes
````
#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2508](https://nalej.atlassian.net/browse/NP-2508)

#### Screenshots (if appropriate)

#### Questions
